### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ You can simply include the ``DateExtension.swift`` file to your project. To make
 pod 'SwiftDateExtension'
 ```
 
-####License
+#### License
 
 This component is available under MIT license.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
